### PR TITLE
Remove build dependency on libhid

### DIFF
--- a/src/plugins/platforms/palm/hidd_support.h
+++ b/src/plugins/platforms/palm/hidd_support.h
@@ -1,0 +1,9 @@
+#ifndef HID_SUPPORT_H_
+#define HID_SUPPORT_H_
+
+#define DEV_TYPE_KEYBOARD   0x00
+#define DEV_TYPE_MOUSE      0x01
+#define DEV_TYPE_JOYSTICK   0x02
+
+
+#endif

--- a/src/plugins/platforms/palm/hiddkbd_qpa.cpp
+++ b/src/plugins/platforms/palm/hiddkbd_qpa.cpp
@@ -20,6 +20,7 @@
 **
 ****************************************************************************/
 
+#include <unistd.h>
 #include <Qt>
 #include <QKeyEvent>
 #include <QApplication>
@@ -28,11 +29,12 @@
 #include <errno.h>
 #include <glib.h>
 #include "hiddkbd_qpa.h"
-#include <hid/IncsPublic/HidLib.h>
+#include "hidd_support.h"
 #include "InputControl.h"
 #include "NyxInputControl.h"
 #include "webosDeviceKeymap.h"
 #include <dlfcn.h>
+#include <linux/input.h>
 
 #include <QWSKeyboardHandler>
 #include <QKbdDriverFactory>

--- a/src/plugins/platforms/palm/hiddkbd_qpa.h
+++ b/src/plugins/platforms/palm/hiddkbd_qpa.h
@@ -28,7 +28,7 @@
 #include <qsocketnotifier.h>
 #include <map>
 #include "webosDeviceKeymap.h"
-#include <hid/IncsPublic/HidLib.h>
+#include "hidd_support.h"
 
 #include <nyx/nyx_client.h>
 #include <QWSKeyboardHandler>

--- a/src/plugins/platforms/palm/hiddtp_qpa.cpp
+++ b/src/plugins/platforms/palm/hiddtp_qpa.cpp
@@ -20,7 +20,7 @@
 **
 ****************************************************************************/
 
-
+#include <unistd.h>
 #include <fcntl.h>
 #include <sys/socket.h>
 #include <sys/un.h>

--- a/src/plugins/platforms/palm/hiddtp_qpa.h
+++ b/src/plugins/platforms/palm/hiddtp_qpa.h
@@ -31,7 +31,7 @@
 #include <stdio.h>
 #include <glib.h>
 
-#include <hid/IncsPublic/HidLib.h>
+#include "hidd_support.h"
 #include <nyx/nyx_client.h>
 
 #include "FlickGesture.h"

--- a/src/plugins/platforms/palm/palm.pro
+++ b/src/plugins/platforms/palm/palm.pro
@@ -38,7 +38,7 @@ SOURCES +=  hiddtp_qpa.cpp \
             NyxInputControl.cpp \
             hiddkbd_qpa.cpp
 
-LIBS_PRIVATE += -lnyx -lhid -ldl
+LIBS_PRIVATE += -lnyx -ldl
 }
 
 include(../fontdatabases/genericunix/genericunix.pri)


### PR DESCRIPTION
This will remove the build dependency on libhid which is not realy needed anymore due to the use of nyx-lib. All needed constants are added within a hidd-support.h header file or with the inclusion of other system headers files. Without theses changes qt4 is not compilable for other machines than qemu*.

regards,
Simon
