### PR TITLE
Use upstream judgement of architecture

### DIFF
--- a/configure
+++ b/configure
@@ -3167,9 +3167,9 @@ if [ -z "${CFG_HOST_ARCH}" ]; then
             CFG_HOST_ARCH=i386
         else
             if [ "$OPT_VERBOSE" = "yes" ]; then
-                echo "    64-bit AMD 80x86 (x86_64) (But using 32 bit build)"
+                echo "    64-bit AMD 80x86 (x86_64)"
             fi
-            CFG_HOST_ARCH=i386
+            CFG_HOST_ARCH=x86_64
         fi
         ;;
     *:*:ppc)


### PR DESCRIPTION
- The openwebos/qt builds 32-bit executable qmake-palm on 64-bit machine, this patch should fix the issue.

Open-webOS-DCO-1.0-Signed-off-by: Weiwen Zhao panda.hust@gmail.com
