### PR TITLE
palm: fix regression introduce with the latest update to 4.8.3

### DIFF
--- a/src/plugins/platforms/palm/palm.pro
+++ b/src/plugins/platforms/palm/palm.pro
@@ -42,7 +42,7 @@ webos {
                    qeglfswindowsurface.h \
                    qeglfsscreen.h
         DEFINES += TARGET_DEVICE
-        LIBS_PRIVATE += -lnyx -lhid -ldl
+        LIBS_PRIVATE += -lnyx -ldl
     }
 }
 


### PR DESCRIPTION
With fb493b935f8271b11e031118f09541e28a8bd293 linkage against libhid was
removed from build configuration which was added back with the latest
update to 4.8.3 by commit 85578ddd1387832f3a59a7e347a4eecf452aefae

This is rather critical as it breaks the build for non qemu machines.

Open-webOS-DCO-1.0-Signed-off-by: Simon Busch morphis@gravedo.de
