### PR TITLE
Use RasterPixmapData until we fix QEglGLPixmapData properly

### DIFF
--- a/src/plugins/platforms/palm/qeglfsintegration.cpp
+++ b/src/plugins/platforms/palm/qeglfsintegration.cpp
@@ -55,6 +55,7 @@
 #include <EGL/egl.h>
 #include <QDebug>
 
+#include "QtOpenGL/private/qpixmapdata_gl_p.h"
 QT_BEGIN_NAMESPACE
 
 QPlatformClipboard* QEglFSIntegration::clipboard() const {
@@ -101,7 +102,12 @@ QPixmapData *QEglFSIntegration::createPixmapData(QPixmapData::PixelType type) co
     if(soft)
       return new QRasterPixmapData(type);
     else
-      return new QEglGLPixmapData(type);
+// We have to think about either improving on the performance of EglGLPixmapData
+// or having QWebKit not copy around so many images at all. For now Raster gives
+// us *just* about enough speed.
+// FIXME make QEglGLPixmapData faster and re-enable here.
+//      return new QEglGLPixmapData(type);
+      return new QRasterPixmapData(type);
 }
 
 QPlatformWindow *QEglFSIntegration::createPlatformWindow(QWidget *widget, WId winId) const

--- a/src/plugins/platforms/webos/qwebosintegration.cpp
+++ b/src/plugins/platforms/webos/qwebosintegration.cpp
@@ -72,7 +72,12 @@ QPixmapData *QWebOSIntegration::createPixmapData(QPixmapData::PixelType type) co
     if(m_offscreen)
       return new QRasterPixmapData(type);
     else
-      return new QEglGLPixmapData(type);
+// We have to think about either improving on the performance of EglGLPixmapData
+// or having QWebKit not copy around so many images at all. For now Raster gives
+// us *just* about enough speed.
+// FIXME make QEglGLPixmapData faster and re-enable here.
+//      return new QEglGLPixmapData(type);
+      return new QRasterPixmapData(type);
 }
 
 QPlatformWindow *QWebOSIntegration::createPlatformWindow(QWidget *widget, WId winId) const


### PR DESCRIPTION
This patch includes both a change to use RasterPixmapData instead of
our own QEglRasterPixmapData as well as a fix to make QEglGLPixmapData
work to begin with. Due to the slow performance of the latter, we
should refrain from using the Egl version until we can either make webkit
not thrash pixmaps so much or improve the copying performance of egl
pixmaps.